### PR TITLE
Fix incorrectly assigning selected class to index

### DIFF
--- a/lib/middleman-navigation/tree.rb
+++ b/lib/middleman-navigation/tree.rb
@@ -40,7 +40,7 @@ module Middleman
         title = node.data.navigation[:title] || node.data.title
         url = node.data.navigation[:destination] || node.url
 
-        level.item node.destination_path, title, url, :highlights_on => %r(#{url}(#{@app.index_file})?)
+        level.item node.destination_path, title, url, :highlights_on => %r(^#{url}(#{@app.index_file})?$)
       end
     end
   end


### PR DESCRIPTION
I've simply added ^ and $ to the regex fed to the highlights_on option so now
it only highlights exact matches and not partial matches.

[fix #3]
