### PR TITLE
Possible fix for #4: lookup root by original path

### DIFF
--- a/lib/middleman-navigation/tree.rb
+++ b/lib/middleman-navigation/tree.rb
@@ -3,7 +3,7 @@ module Middleman
     class Tree
       def self.build(sitemap)
         @app = sitemap.app
-        @root = sitemap.find_resource_by_destination_path @app.http_prefix+@app.index_file
+        @root = sitemap.find_resource_by_path @app.index_file
 
         unless @root.blank?
           SimpleNavigation::Configuration.run do |navigation|

--- a/middleman-navigation.gemspec
+++ b/middleman-navigation.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   
-  s.add_dependency("middleman-core", ["~> 3.2.1"])
-  s.add_dependency("simple-navigation", ["> 3.0.0"])
+  s.add_dependency("middleman-core", ["~> 3.2"])
+  s.add_dependency("simple-navigation", ["~> 3.0"])
 
-  s.add_development_dependency "activesupport", ["~> 3.2.6"]
+  s.add_development_dependency "activesupport", ["~> 3.2"]
   s.add_development_dependency "nokogiri"
   s.add_development_dependency "bundler"
   s.add_development_dependency "gem-release" # Seems a better fit than Jeweler.


### PR DESCRIPTION
As discussed in #4.

I did have to relax the dependencies to the two digit precision to get a recent simple-navigation and to work with the latest middleman branches. More explanation at https://github.com/middleman/middleman/issues/501#issuecomment-43938278.

I also have one failing test, but it fails in my environment with the original code as well. Hopefully you can figure out what's causing this:

```
    Then the Subpage menu item should not be selected # features/step_definitions/nav_steps.rb:1
      expected "HomeAnotherChildSubpage" not to match "Subpage" (RSpec::Expectations::ExpectationNotMetError)
      features/basic.feature:14:in `Then the Subpage menu item should not be selected'
```
